### PR TITLE
Create Ticket Support Resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,30 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.5</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.rodrigolopes.ms</groupId>
 	<artifactId>support_ticket</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>support_ticket</name>
 	<description>Demo project for Spring Boot</description>
-	<url/>
+	<url />
 	<licenses>
-		<license/>
+		<license />
 	</licenses>
 	<developers>
-		<developer/>
+		<developer />
 	</developers>
 	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
+		<connection />
+		<developerConnection />
+		<tag />
+		<url />
 	</scm>
 	<properties>
 		<java.version>21</java.version>
@@ -46,7 +47,20 @@
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka</artifactId>
 		</dependency>
-
+		<!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.19.0</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.13.4</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,13 @@
 			<version>5.13.4</version>
 			<scope>test</scope>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.27.4</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,12 @@
 			<scope>test</scope>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.13.4</version>
-			<scope>test</scope>
-		</dependency>
+<!--		<dependency>-->
+<!--			<groupId>org.junit.jupiter</groupId>-->
+<!--			<artifactId>junit-jupiter-engine</artifactId>-->
+<!--			<version>5.13.4</version>-->
+<!--			<scope>test</scope>-->
+<!--		</dependency>-->
 		<!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<org.mapstruct.version>1.6.3</org.mapstruct.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -67,6 +68,11 @@
 			<artifactId>assertj-core</artifactId>
 			<version>3.27.4</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>${org.mapstruct.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -111,6 +117,11 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+						</path>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${org.mapstruct.version}</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/config/JpaAutidingConfig.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/config/JpaAutidingConfig.java
@@ -1,0 +1,8 @@
+package com.rodrigolopes.ms.support_ticket.config;
+
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+public class JpaAutidingConfig {
+    
+}

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/config/JpaAutidingConfig.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/config/JpaAutidingConfig.java
@@ -1,7 +1,9 @@
 package com.rodrigolopes.ms.support_ticket.config;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@Configuration
 @EnableJpaAuditing
 public class JpaAutidingConfig {
     

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
@@ -2,17 +2,28 @@ package com.rodrigolopes.ms.support_ticket.controllers;
 
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.rodrigolopes.ms.support_ticket.dto.ResponseTicketDTO;
+import com.rodrigolopes.ms.support_ticket.services.SupportTicketService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-
 
 @RestController
 @RequestMapping("/tickets")
 public class SupportTicketController {
 
+    @Autowired
+    private SupportTicketService supportTicketService;
+
     @GetMapping()
-    public ResponseEntity<String> index() {
-        return ResponseEntity.ok().body("hello world");
+    public ResponseEntity<Page<ResponseTicketDTO>> index(Pageable pageable) {
+        var data = this.supportTicketService.getAll(pageable);
+        ;
+        return ResponseEntity.ok().body(data);
     }
 
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
@@ -45,7 +45,7 @@ public class SupportTicketController {
         var response = this.supportTicketService.create(body);
         var uri = UriComponentsBuilder.fromPath("/tickets/{id}").buildAndExpand(response.id()).toUri();
         return ResponseEntity.created(uri)
-                .body(this.supportTicketService.create(body));
+                .body(response);
     }
 
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
@@ -2,9 +2,13 @@ package com.rodrigolopes.ms.support_ticket.controllers;
 
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import com.rodrigolopes.ms.support_ticket.dto.RequestTicketDTO;
 import com.rodrigolopes.ms.support_ticket.dto.ResponseTicketDTO;
 import com.rodrigolopes.ms.support_ticket.services.SupportTicketService;
+
+import jakarta.validation.Valid;
 
 import java.util.UUID;
 
@@ -15,6 +19,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @RestController
 @RequestMapping("/tickets")
@@ -31,8 +37,16 @@ public class SupportTicketController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ResponseTicketDTO> getMethodName(@PathVariable String id) {
+    public ResponseEntity<ResponseTicketDTO> show(@PathVariable String id) {
         return ResponseEntity.ok().body(this.supportTicketService.getById(UUID.fromString(id)));
+    }
+
+    @PostMapping()
+    public ResponseEntity<ResponseTicketDTO> create(@Valid @RequestBody RequestTicketDTO body) {
+        var response = this.supportTicketService.create(body);
+        var uri = UriComponentsBuilder.fromPath("/tickets/{id}").buildAndExpand(response.id()).toUri();
+        return ResponseEntity.created(uri)
+                .body(this.supportTicketService.create(body));
     }
 
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
@@ -18,7 +18,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
@@ -6,11 +6,15 @@ import org.springframework.web.bind.annotation.RestController;
 import com.rodrigolopes.ms.support_ticket.dto.ResponseTicketDTO;
 import com.rodrigolopes.ms.support_ticket.services.SupportTicketService;
 
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RestController
 @RequestMapping("/tickets")
@@ -24,6 +28,11 @@ public class SupportTicketController {
         var data = this.supportTicketService.getAll(pageable);
         ;
         return ResponseEntity.ok().body(data);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ResponseTicketDTO> getMethodName(@PathVariable String id) {
+        return ResponseEntity.ok().body(this.supportTicketService.getById(UUID.fromString(id)));
     }
 
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PutMapping;
+
 
 @RestController
 @RequestMapping("/tickets")
@@ -46,6 +48,12 @@ public class SupportTicketController {
         var uri = UriComponentsBuilder.fromPath("/tickets/{id}").buildAndExpand(response.id()).toUri();
         return ResponseEntity.created(uri)
                 .body(response);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ResponseTicketDTO> update(@PathVariable String id, @Valid @RequestBody RequestTicketDTO data) {
+        var response = this.supportTicketService.update(UUID.fromString(id), data);
+        return ResponseEntity.ok().body(response);
     }
 
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -54,6 +55,12 @@ public class SupportTicketController {
     public ResponseEntity<ResponseTicketDTO> update(@PathVariable String id, @Valid @RequestBody RequestTicketDTO data) {
         var response = this.supportTicketService.update(UUID.fromString(id), data);
         return ResponseEntity.ok().body(response);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable String id) {
+        this.supportTicketService.delete(UUID.fromString(id));
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @RestController
 @RequestMapping("/tickets")
-public class TicketSupportController {
+public class SupportTicketController {
 
     @GetMapping()
     public ResponseEntity<String> index() {

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/TicketSupportController.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/controllers/TicketSupportController.java
@@ -1,0 +1,18 @@
+package com.rodrigolopes.ms.support_ticket.controllers;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+
+@RestController
+@RequestMapping("/tickets")
+public class TicketSupportController {
+
+    @GetMapping()
+    public ResponseEntity<String> index() {
+        return ResponseEntity.ok().body("hello world");
+    }
+
+}

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/dto/ErrorResponseDTO.java
@@ -1,0 +1,13 @@
+package com.rodrigolopes.ms.support_ticket.dto;
+
+import java.util.Map;
+
+import org.hibernate.query.results.ResultBuilder;
+
+public record ErrorResponseDTO(String path, String message, int status, Map<String, String> errors) {
+
+    public ErrorResponseDTO(String path, String message, int status) {
+        this(path, message, status, null);
+    }
+
+}

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/dto/RequestTicketDTO.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/dto/RequestTicketDTO.java
@@ -2,6 +2,7 @@ package com.rodrigolopes.ms.support_ticket.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record RequestTicketDTO(@NotBlank String title, @NotBlank String description, String status) {
+public record RequestTicketDTO(@NotBlank(message = "Title must not be empty") String title,
+        @NotBlank(message = "Description must not be empty") String description, String status) {
 
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/dto/RequestTicketDTO.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/dto/RequestTicketDTO.java
@@ -1,5 +1,7 @@
 package com.rodrigolopes.ms.support_ticket.dto;
 
-public record RequestTicketDTO(String title , String description, String status) {
+import jakarta.validation.constraints.NotBlank;
+
+public record RequestTicketDTO(@NotBlank String title, @NotBlank String description, String status) {
 
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/dto/RequestTicketDTO.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/dto/RequestTicketDTO.java
@@ -1,0 +1,5 @@
+package com.rodrigolopes.ms.support_ticket.dto;
+
+public record RequestTicketDTO(String title , String description, String status) {
+
+}

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/dto/RequestTicketDTO.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/dto/RequestTicketDTO.java
@@ -1,8 +1,12 @@
 package com.rodrigolopes.ms.support_ticket.dto;
 
+import com.rodrigolopes.ms.support_ticket.enums.TicketStatus;
+import com.rodrigolopes.ms.support_ticket.validations.ValidEnum;
+
 import jakarta.validation.constraints.NotBlank;
 
 public record RequestTicketDTO(@NotBlank(message = "Title must not be empty") String title,
-        @NotBlank(message = "Description must not be empty") String description, String status) {
+        @NotBlank(message = "Description must not be empty") String description, 
+        @ValidEnum(enumClass = TicketStatus.class, message = "Status must be one of: OPEN, CLOSED, PENDING") String status) {
 
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/dto/ResponseTicketDTO.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/dto/ResponseTicketDTO.java
@@ -1,0 +1,14 @@
+package com.rodrigolopes.ms.support_ticket.dto;
+
+import java.util.UUID;
+
+public record ResponseTicketDTO(
+    UUID id,
+    String title,
+    String description,
+    String status,
+    String createdAt,
+    String updatedAt
+) {
+
+}

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/entities/SupportTicket.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/entities/SupportTicket.java
@@ -39,7 +39,9 @@ public class SupportTicket {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
+    @Column(nullable = false)
     private String title;
+
     private String description;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/entities/SupportTicket.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/entities/SupportTicket.java
@@ -1,0 +1,48 @@
+package com.rodrigolopes.ms.support_ticket.entities;
+
+import java.util.Date;
+import java.util.UUID;
+
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+public class SupportTicket {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String title;
+    private String description;
+
+    private String status;
+
+    @CreatedDate
+    private Date createdAt;
+
+    @UpdateTimestamp
+    private Date updatedAt;
+
+
+    
+}

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/entities/SupportTicket.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/entities/SupportTicket.java
@@ -20,11 +20,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@Builder
 @Entity
 @Getter
 @Setter

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/entities/SupportTicket.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/entities/SupportTicket.java
@@ -9,6 +9,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import com.rodrigolopes.ms.support_ticket.enums.TicketStatus;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -40,7 +42,8 @@ public class SupportTicket {
     private String title;
     private String description;
 
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private TicketStatus status;
 
     @CreatedDate
     @Column(nullable = false, updatable = false, name = "createdAt")

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/entities/SupportTicket.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/entities/SupportTicket.java
@@ -44,6 +44,7 @@ public class SupportTicket {
     @Column(nullable = false)
     private String title;
 
+    @Column(nullable = false)
     private String description;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/entities/SupportTicket.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/entities/SupportTicket.java
@@ -45,7 +45,7 @@ public class SupportTicket {
     private String description;
 
     @Enumerated(EnumType.STRING)
-    private TicketStatus status;
+    private TicketStatus status = TicketStatus.OPEN;
 
     @CreatedDate
     @Column(nullable = false, updatable = false, name = "createdAt")

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/entities/SupportTicket.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/entities/SupportTicket.java
@@ -1,13 +1,17 @@
 package com.rodrigolopes.ms.support_ticket.entities;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
 
 import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -25,6 +29,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(of = "id")
+@EntityListeners(AuditingEntityListener.class)
 public class SupportTicket {
 
 
@@ -38,10 +43,12 @@ public class SupportTicket {
     private String status;
 
     @CreatedDate
-    private Date createdAt;
+    @Column(nullable = false, updatable = false, name = "createdAt")
+    private Instant createdAt;
 
-    @UpdateTimestamp
-    private Date updatedAt;
+    @LastModifiedDate
+    @Column(nullable = false, name = "updatedAt")
+    private Instant updatedAt;
 
 
     

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/enums/TicketStatus.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/enums/TicketStatus.java
@@ -1,0 +1,7 @@
+package com.rodrigolopes.ms.support_ticket.enums;
+
+public enum TicketStatus {
+    OPEN, 
+    IN_PROGRESS, 
+    RESOLVED
+}

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/exceptions/ControllerErrorHandler.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/exceptions/ControllerErrorHandler.java
@@ -1,7 +1,14 @@
 package com.rodrigolopes.ms.support_ticket.exceptions;
 
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -12,10 +19,30 @@ import jakarta.servlet.http.HttpServletRequest;
 
 @ControllerAdvice
 public class ControllerErrorHandler {
-    
-    
+
     @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<ErrorResponseDTO> handleEntityNotFoundException(EntityNotFoundException ex, HttpServletRequest request) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(request.getRequestURI(), ex.getMessage(), HttpStatus.NOT_FOUND.value()));
+    public ResponseEntity<ErrorResponseDTO> handleEntityNotFoundException(EntityNotFoundException ex,
+            HttpServletRequest request) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponseDTO(request.getRequestURI(), ex.getMessage(), HttpStatus.NOT_FOUND.value()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponseDTO> handleIllegalArgumentException(IllegalArgumentException ex,
+            HttpServletRequest request) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponseDTO(request.getRequestURI(), ex.getMessage(), HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponseDTO> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex,
+            HttpServletRequest request, BindingResult result) {
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError error : result.getFieldErrors()) {
+            errors.put(error.getField(), error.getDefaultMessage());
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponseDTO(request.getRequestURI(), ex.getMessage(), HttpStatus.BAD_REQUEST.value(),
+                        errors));
     }
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/exceptions/ControllerErrorHandler.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/exceptions/ControllerErrorHandler.java
@@ -1,0 +1,21 @@
+package com.rodrigolopes.ms.support_ticket.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import com.rodrigolopes.ms.support_ticket.dto.ErrorResponseDTO;
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+
+@ControllerAdvice
+public class ControllerErrorHandler {
+    
+    
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponseDTO> handleEntityNotFoundException(EntityNotFoundException ex, HttpServletRequest request) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(request.getRequestURI(), ex.getMessage(), HttpStatus.NOT_FOUND.value()));
+    }
+}

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/exceptions/ControllerErrorHandler.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/exceptions/ControllerErrorHandler.java
@@ -5,8 +5,6 @@ import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/exceptions/ControllerErrorHandler.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/exceptions/ControllerErrorHandler.java
@@ -1,14 +1,13 @@
 package com.rodrigolopes.ms.support_ticket.exceptions;
 
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -36,13 +35,13 @@ public class ControllerErrorHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponseDTO> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex,
-            HttpServletRequest request, BindingResult result) {
+            HttpServletRequest request) {
+
         Map<String, String> errors = new HashMap<>();
-        for (FieldError error : result.getFieldErrors()) {
-            errors.put(error.getField(), error.getDefaultMessage());
-        }
+        ex.getBindingResult().getFieldErrors()
+                .forEach(error -> errors.put(error.getField(), error.getDefaultMessage()));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponseDTO(request.getRequestURI(), ex.getMessage(), HttpStatus.BAD_REQUEST.value(),
+                .body(new ErrorResponseDTO(request.getRequestURI(), "Invalid arguments!", HttpStatus.BAD_REQUEST.value(),
                         errors));
     }
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/exceptions/ControllerErrorHandler.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/exceptions/ControllerErrorHandler.java
@@ -19,29 +19,34 @@ import jakarta.servlet.http.HttpServletRequest;
 @ControllerAdvice
 public class ControllerErrorHandler {
 
-    @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<ErrorResponseDTO> handleEntityNotFoundException(EntityNotFoundException ex,
-            HttpServletRequest request) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponseDTO(request.getRequestURI(), ex.getMessage(), HttpStatus.NOT_FOUND.value()));
-    }
+        @ExceptionHandler(EntityNotFoundException.class)
+        public ResponseEntity<ErrorResponseDTO> handleEntityNotFoundException(EntityNotFoundException ex,
+                        HttpServletRequest request) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                .body(new ErrorResponseDTO(request.getRequestURI(), ex.getMessage(),
+                                                HttpStatus.NOT_FOUND.value()));
+        }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponseDTO> handleIllegalArgumentException(IllegalArgumentException ex,
-            HttpServletRequest request) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponseDTO(request.getRequestURI(), ex.getMessage(), HttpStatus.BAD_REQUEST.value()));
-    }
+        @ExceptionHandler(IllegalArgumentException.class)
+        public ResponseEntity<ErrorResponseDTO> handleIllegalArgumentException(IllegalArgumentException ex,
+                        HttpServletRequest request) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(new ErrorResponseDTO(request.getRequestURI(), ex.getMessage(),
+                                                HttpStatus.BAD_REQUEST.value()));
+        }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponseDTO> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex,
-            HttpServletRequest request) {
+        @ExceptionHandler(MethodArgumentNotValidException.class)
+        public ResponseEntity<ErrorResponseDTO> handleMethodArgumentNotValidException(
+                        MethodArgumentNotValidException ex,
+                        HttpServletRequest request) {
 
-        Map<String, String> errors = new HashMap<>();
-        ex.getBindingResult().getFieldErrors()
-                .forEach(error -> errors.put(error.getField(), error.getDefaultMessage()));
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponseDTO(request.getRequestURI(), "Invalid arguments!", HttpStatus.BAD_REQUEST.value(),
-                        errors));
-    }
+                Map<String, String> errors = new HashMap<>();
+                ex.getBindingResult().getFieldErrors()
+                                .forEach(error -> errors.put(error.getField(), error.getDefaultMessage()));
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(new ErrorResponseDTO(request.getRequestURI(), "Invalid arguments!",
+                                                HttpStatus.BAD_REQUEST.value(),
+                                                errors));
+        }
+
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/mapper/TicketMapper.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/mapper/TicketMapper.java
@@ -1,0 +1,21 @@
+package com.rodrigolopes.ms.support_ticket.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.rodrigolopes.ms.support_ticket.dto.RequestTicketDTO;
+import com.rodrigolopes.ms.support_ticket.dto.ResponseTicketDTO;
+import com.rodrigolopes.ms.support_ticket.entities.SupportTicket;
+
+@Mapper(componentModel = "spring")
+public interface TicketMapper {
+
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "id", ignore = true)
+    SupportTicket toEntity(RequestTicketDTO dto);
+
+    ResponseTicketDTO toResponseDto(SupportTicket entity);
+    SupportTicket toEntity(ResponseTicketDTO dto);
+    RequestTicketDTO toRequestDto(SupportTicket entity);
+}

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/repositories/TicketSupportRepository.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/repositories/TicketSupportRepository.java
@@ -8,4 +8,6 @@ import com.rodrigolopes.ms.support_ticket.entities.SupportTicket;
 
 public interface TicketSupportRepository extends JpaRepository<SupportTicket, UUID> {
     
+
+    Boolean existsByTitle(String title);
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/repositories/TicketSupportRepository.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/repositories/TicketSupportRepository.java
@@ -10,4 +10,6 @@ public interface TicketSupportRepository extends JpaRepository<SupportTicket, UU
     
 
     Boolean existsByTitle(String title);
+
+    boolean existsByTitleAndIdNot(String title, UUID id);
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/repositories/TicketSupportRepository.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/repositories/TicketSupportRepository.java
@@ -1,0 +1,11 @@
+package com.rodrigolopes.ms.support_ticket.repositories;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.rodrigolopes.ms.support_ticket.entities.SupportTicket;
+
+public interface TicketSupportRepository extends JpaRepository<SupportTicket, UUID> {
+    
+}

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
@@ -52,4 +52,13 @@ public class SupportTicketService {
 
         return ticketMapper.toResponseDto(updatedTicket);
     }
+
+    public void delete(UUID id) {
+
+        if (!ticketSupportRepository.existsById(id)) {
+            throw new EntityNotFoundException("Ticket not found with id: " + id);
+        }
+        
+        ticketSupportRepository.deleteById(id);
+    }
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
@@ -4,12 +4,16 @@ import com.fasterxml.jackson.databind.DatabindException;
 import com.rodrigolopes.ms.support_ticket.enums.TicketStatus;
 import com.rodrigolopes.ms.support_ticket.mapper.TicketMapper;
 
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.rodrigolopes.ms.support_ticket.dto.RequestTicketDTO;
 import com.rodrigolopes.ms.support_ticket.dto.ResponseTicketDTO;
 import com.rodrigolopes.ms.support_ticket.repositories.TicketSupportRepository;
+
+import jakarta.persistence.EntityNotFoundException;
 
 @Service
 public class SupportTicketService {
@@ -30,5 +34,22 @@ public class SupportTicketService {
         var createdTicket = ticketSupportRepository.save(supportTicket);
         return ticketMapper.toResponseDto(createdTicket);
 
+    }
+
+    public ResponseTicketDTO update(UUID id, RequestTicketDTO requestDto) {
+        var existingTicket = ticketSupportRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Ticket not found with id: " + id));
+
+        if (ticketSupportRepository.existsByTitleAndIdNot(requestDto.title(), id)) {
+            throw new IllegalArgumentException("A ticket with this title already exists in another record.");
+        }
+        
+        existingTicket.setTitle(requestDto.title());
+        existingTicket.setDescription(requestDto.description());
+        existingTicket.setStatus(TicketStatus.valueOf(requestDto.status()));
+
+        var updatedTicket = ticketSupportRepository.save(existingTicket);
+
+        return ticketMapper.toResponseDto(updatedTicket);
     }
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
@@ -17,7 +17,7 @@ public class SupportTicketService {
 
 
     public ResponseTicketDTO createTicket(RequestTicketDTO requestTicketDTO) {
-        
+        return new ResponseTicketDTO();
 
     }
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
@@ -7,6 +7,8 @@ import com.rodrigolopes.ms.support_ticket.mapper.TicketMapper;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.rodrigolopes.ms.support_ticket.dto.RequestTicketDTO;
@@ -24,6 +26,10 @@ public class SupportTicketService {
     @Autowired
     private TicketMapper ticketMapper;
 
+    public Page<ResponseTicketDTO> getAll(Pageable pageable) {
+        return ticketSupportRepository.findAll(pageable)
+                .map(ticketMapper::toResponseDto);
+    }
 
     public ResponseTicketDTO getById(UUID id) {
         var supportTicket = ticketSupportRepository.findById(id)
@@ -50,7 +56,7 @@ public class SupportTicketService {
         if (ticketSupportRepository.existsByTitleAndIdNot(requestDto.title(), id)) {
             throw new IllegalArgumentException("A ticket with this title already exists in another record.");
         }
-        
+
         existingTicket.setTitle(requestDto.title());
         existingTicket.setDescription(requestDto.description());
         existingTicket.setStatus(TicketStatus.valueOf(requestDto.status()));

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
@@ -1,0 +1,20 @@
+package com.rodrigolopes.ms.support_ticket.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.rodrigolopes.ms.support_ticket.repositories.TicketSupportRepository;
+
+@Service
+public class SupportTicketService {
+    
+
+    @Autowired
+    private TicketSupportRepository ticketSupportRepository;
+
+
+
+    public ResponseTicketDTO createTicket(RequestTicketDTO requestTicketDTO) {
+        
+    }
+}

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
@@ -11,10 +11,8 @@ import com.rodrigolopes.ms.support_ticket.dto.RequestTicketDTO;
 import com.rodrigolopes.ms.support_ticket.dto.ResponseTicketDTO;
 import com.rodrigolopes.ms.support_ticket.repositories.TicketSupportRepository;
 
-
 @Service
 public class SupportTicketService {
-    
 
     @Autowired
     private TicketSupportRepository ticketSupportRepository;
@@ -22,9 +20,11 @@ public class SupportTicketService {
     @Autowired
     private TicketMapper ticketMapper;
 
+    public ResponseTicketDTO create(RequestTicketDTO requestTicketDTO) {
 
-    public ResponseTicketDTO createTicket(RequestTicketDTO requestTicketDTO) {
-        
+        if (this.ticketSupportRepository.existsByTitle(requestTicketDTO.title())) {
+            throw new IllegalArgumentException("A ticket with this title already exists.");
+        }
         var supportTicket = ticketMapper.toEntity(requestTicketDTO);
 
         var createdTicket = ticketSupportRepository.save(supportTicket);

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
@@ -3,6 +3,8 @@ package com.rodrigolopes.ms.support_ticket.services;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.rodrigolopes.ms.support_ticket.dto.RequestTicketDTO;
+import com.rodrigolopes.ms.support_ticket.dto.ResponseTicketDTO;
 import com.rodrigolopes.ms.support_ticket.repositories.TicketSupportRepository;
 
 @Service
@@ -16,5 +18,6 @@ public class SupportTicketService {
 
     public ResponseTicketDTO createTicket(RequestTicketDTO requestTicketDTO) {
         
+
     }
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
@@ -11,8 +11,6 @@ import com.rodrigolopes.ms.support_ticket.dto.RequestTicketDTO;
 import com.rodrigolopes.ms.support_ticket.dto.ResponseTicketDTO;
 import com.rodrigolopes.ms.support_ticket.repositories.TicketSupportRepository;
 
-import java.util.Date;
-import java.util.UUID;
 
 @Service
 public class SupportTicketService {
@@ -27,6 +25,10 @@ public class SupportTicketService {
 
     public ResponseTicketDTO createTicket(RequestTicketDTO requestTicketDTO) {
         
+        var supportTicket = ticketMapper.toEntity(requestTicketDTO);
+
+        var createdTicket = ticketSupportRepository.save(supportTicket);
+        return ticketMapper.toResponseDto(createdTicket);
 
     }
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
@@ -24,6 +24,13 @@ public class SupportTicketService {
     @Autowired
     private TicketMapper ticketMapper;
 
+
+    public ResponseTicketDTO getById(UUID id) {
+        var supportTicket = ticketSupportRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Ticket not found with id: " + id));
+        return ticketMapper.toResponseDto(supportTicket);
+    }
+
     public ResponseTicketDTO create(RequestTicketDTO requestTicketDTO) {
 
         if (this.ticketSupportRepository.existsByTitle(requestTicketDTO.title())) {
@@ -58,7 +65,7 @@ public class SupportTicketService {
         if (!ticketSupportRepository.existsById(id)) {
             throw new EntityNotFoundException("Ticket not found with id: " + id);
         }
-        
+
         ticketSupportRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/services/SupportTicketService.java
@@ -1,11 +1,18 @@
 package com.rodrigolopes.ms.support_ticket.services;
 
+import com.fasterxml.jackson.databind.DatabindException;
+import com.rodrigolopes.ms.support_ticket.enums.TicketStatus;
+import com.rodrigolopes.ms.support_ticket.mapper.TicketMapper;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.rodrigolopes.ms.support_ticket.dto.RequestTicketDTO;
 import com.rodrigolopes.ms.support_ticket.dto.ResponseTicketDTO;
 import com.rodrigolopes.ms.support_ticket.repositories.TicketSupportRepository;
+
+import java.util.Date;
+import java.util.UUID;
 
 @Service
 public class SupportTicketService {
@@ -14,10 +21,12 @@ public class SupportTicketService {
     @Autowired
     private TicketSupportRepository ticketSupportRepository;
 
+    @Autowired
+    private TicketMapper ticketMapper;
 
 
     public ResponseTicketDTO createTicket(RequestTicketDTO requestTicketDTO) {
-        return new ResponseTicketDTO();
+        
 
     }
 }

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/validations/EnumValidator.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/validations/EnumValidator.java
@@ -1,0 +1,25 @@
+package com.rodrigolopes.ms.support_ticket.validations;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, String> {
+
+    private String[] acceptedValues;
+
+    @Override
+    public void initialize(ValidEnum annotation) {
+        acceptedValues = java.util.Arrays.stream(annotation.enumClass().getEnumConstants())
+                .map(Enum::name)
+                .toArray(String[]::new);
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return true; 
+        for (String s : acceptedValues) {
+            if (s.equals(value)) return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/rodrigolopes/ms/support_ticket/validations/ValidEnum.java
+++ b/src/main/java/com/rodrigolopes/ms/support_ticket/validations/ValidEnum.java
@@ -1,0 +1,17 @@
+package com.rodrigolopes.ms.support_ticket.validations;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = EnumValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEnum {
+    Class<? extends Enum<?>> enumClass();
+    String message() default "Invalid value. Allowed values are {enumClass}";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=support_ticket

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,15 @@
+spring: 
+    application:
+        name: support_ticket
+    datasource:
+        url: jdbc:postgresql://localhost:5432/ticket_db
+        username: user
+        password: password
+        driver-class-name: org.postgresql.Driver
+    jpa:
+        hibernate:
+            ddl-auto: update
+        show-sql: true
+        properties:
+            hibernate:
+                dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
@@ -258,4 +258,22 @@ public class SupportTicketControllerTest {
                                 .andExpect(jsonPath("$.errors").isEmpty());     
         }
 
+
+        @Test
+        @DisplayName("should return 404 when calling the delete endpoint with invalid ID")
+        public void testDeleteWithInvalidId() throws Exception {
+                var invalidId = UUID.randomUUID();
+                var request = delete("/tickets/{id}", invalidId)
+                                .contentType(MediaType.APPLICATION_JSON);
+                BDDMockito.willThrow(new EntityNotFoundException("Ticket not found with id: " + invalidId))
+                                .given(this.supportTicketService).delete(invalidId);
+                mockMvc.perform(request)
+                                .andExpect(status().isNotFound())
+                                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.path").value("/tickets/" + invalidId))
+                                .andExpect(jsonPath("$.message").value("Ticket not found with id: " + invalidId))
+                                .andExpect(jsonPath("$.status").value(404))
+                                .andExpect(jsonPath("$.errors").isEmpty());
+        }
+
 }

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
@@ -110,6 +110,7 @@ public class SupportTicketControllerTest {
 
                 BDDMockito.given(this.supportTicketService.getById(supportTicket.getId()))
                                 .willReturn(responseTicketDTO);
+                                
                 mockMvc.perform(request)
                                 .andExpect(status().isOk())
                                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
@@ -186,6 +186,31 @@ public class SupportTicketControllerTest {
         }
 
         @Test
+        @DisplayName("should return 400 when calling the store endpoint with invalid enum value")
+        public void testStoreWithInvalidEnumValue() throws Exception {
+                String invalidRequestBodyStatus = """
+                                {
+                                    "title": "Sample Ticket",
+                                    "description": "This is a sample ticket description.",
+                                    "status": "INVALID_STATUS"
+                                }
+                                """;
+                var request = post("/tickets")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(invalidRequestBodyStatus);
+                                
+                mockMvc.perform(request)
+                                .andExpect(status().isBadRequest())
+                                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.path").value("/tickets"))
+                                .andExpect(jsonPath("$.message").value("Invalid arguments!"))
+                                .andExpect(jsonPath("$.status").value(400))
+                                .andExpect(jsonPath("$.errors").isNotEmpty())
+                                .andExpect(jsonPath("$.errors.status")
+                                                .value("Status must be one of: OPEN, CLOSED, PENDING"));
+        }
+
+        @Test
         @DisplayName("should return 200 when calling the update endpoint with valid data and ID")
         public void testUpdateWithValidDataAndId() throws Exception {
                 var request = put("/tickets/{id}", supportTicket.getId())
@@ -280,7 +305,7 @@ public class SupportTicketControllerTest {
         public void testDeleteWithValidId() throws Exception {
                 var request = delete("/tickets/{id}", supportTicket.getId())
                                 .contentType(MediaType.APPLICATION_JSON);
-                                
+
                 BDDMockito.willDoNothing().given(this.supportTicketService).delete(supportTicket.getId());
 
                 mockMvc.perform(request)

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
@@ -185,4 +185,23 @@ public class SupportTicketControllerTest {
                                 .andExpect(jsonPath("$.errors.description").value("Description must not be empty"));
         }
 
+        @Test
+        @DisplayName("should return 200 when calling the update endpoint with valid data and ID")
+        public void testUpdateWithValidDataAndId() throws Exception {
+                var request = put("/tickets/{id}", supportTicket.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body);
+                BDDMockito.given(this.supportTicketService.update(Mockito.eq(supportTicket.getId()),
+                                Mockito.any(RequestTicketDTO.class)))
+                                .willReturn(responseTicketDTO);
+                mockMvc.perform(request)
+                                .andExpect(status().isOk())
+                                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.id").value(supportTicket.getId().toString()))
+                                .andExpect(jsonPath("$.title").value(supportTicket.getTitle()))
+                                .andExpect(jsonPath("$.description").value(supportTicket.getDescription()))
+                                .andExpect(jsonPath("$.status").value(supportTicket.getStatus().name()));
+        }
+        
+
 }

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
@@ -239,7 +239,7 @@ public class SupportTicketControllerTest {
                                 .andExpect(jsonPath("$.errors.title").value("Title must not be empty"))
                                 .andExpect(jsonPath("$.errors.description").value("Description must not be empty"));
         }
-        
+
         @Test
         @DisplayName("should return 400 when calling the update endpoint with duplicated title")
         public void testUpdateWithDuplicatedTitle() throws Exception {
@@ -255,9 +255,8 @@ public class SupportTicketControllerTest {
                                 .andExpect(jsonPath("$.path").value("/tickets/" + supportTicket.getId()))
                                 .andExpect(jsonPath("$.message").value("A ticket with this title already exists."))
                                 .andExpect(jsonPath("$.status").value(400))
-                                .andExpect(jsonPath("$.errors").isEmpty());     
+                                .andExpect(jsonPath("$.errors").isEmpty());
         }
-
 
         @Test
         @DisplayName("should return 404 when calling the delete endpoint with invalid ID")
@@ -274,6 +273,18 @@ public class SupportTicketControllerTest {
                                 .andExpect(jsonPath("$.message").value("Ticket not found with id: " + invalidId))
                                 .andExpect(jsonPath("$.status").value(404))
                                 .andExpect(jsonPath("$.errors").isEmpty());
+        }
+
+        @Test
+        @DisplayName("should return 204 when calling the delete endpoint with valid ID")
+        public void testDeleteWithValidId() throws Exception {
+                var request = delete("/tickets/{id}", supportTicket.getId())
+                                .contentType(MediaType.APPLICATION_JSON);
+                                
+                BDDMockito.willDoNothing().given(this.supportTicketService).delete(supportTicket.getId());
+
+                mockMvc.perform(request)
+                                .andExpect(status().isNoContent());
         }
 
 }

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
@@ -1,19 +1,39 @@
 package com.rodrigolopes.ms.support_ticket.controllers;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.assertj.MockMvcTester.MockMvcRequestBuilder;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.catalina.connector.Request;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rodrigolopes.ms.support_ticket.dto.RequestTicketDTO;
+import com.rodrigolopes.ms.support_ticket.dto.ResponseTicketDTO;
+import com.rodrigolopes.ms.support_ticket.entities.SupportTicket;
+import com.rodrigolopes.ms.support_ticket.enums.TicketStatus;
 import com.rodrigolopes.ms.support_ticket.services.SupportTicketService;
 
 @WebMvcTest(SupportTicketController.class)
@@ -25,16 +45,58 @@ public class SupportTicketControllerTest {
     @MockitoBean
     private SupportTicketService supportTicketService;
 
+    SupportTicket supportTicket;
+    ResponseTicketDTO responseTicketDTO;
+    RequestTicketDTO requestTicketDTO;
+    Page<ResponseTicketDTO> responseTicketDTOPage;
+
+    String body;
+
+    @BeforeEach
+    public void setup() throws JsonProcessingException {
+        supportTicket = SupportTicket.builder()
+                .id(UUID.randomUUID())
+                .title("Sample Ticket")
+                .description("This is a sample ticket description.")
+                .status(TicketStatus.OPEN)
+                .build();
+        responseTicketDTO = new ResponseTicketDTO(
+                supportTicket.getId(),
+                supportTicket.getTitle(),
+                supportTicket.getDescription(),
+                supportTicket.getStatus().name(),
+                new Date().toString(),
+                new Date().toString());
+
+        requestTicketDTO = new RequestTicketDTO(
+                supportTicket.getTitle(),
+                supportTicket.getDescription(),
+                supportTicket.getStatus().name());
+
+        responseTicketDTOPage = new PageImpl<>(List.of(responseTicketDTO), PageRequest.of(0, 100),
+                1);
+
+        body = new ObjectMapper().writeValueAsString(requestTicketDTO);
+
+    }
+
     @Test
     @DisplayName("Should return 200 when calling the index endpoint")
     public void testIndex() throws Exception {
 
-       var request = get("/tickets")
-               .contentType(MediaType.APPLICATION_JSON);
+        var request = get("/tickets")
+                .contentType(MediaType.APPLICATION_JSON);
 
+        BDDMockito.given(this.supportTicketService.getAll(Mockito.any(Pageable.class)))
+                .willReturn(responseTicketDTOPage);
 
         mockMvc.perform(request)
-               .andExpect(status().isOk()).andExpect(content().string("hello world"));
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content[0].id").value(supportTicket.getId().toString()))
+                .andExpect(jsonPath("$.content[0].title").value(supportTicket.getTitle()))
+                .andExpect(jsonPath("$.content[0].description").value(supportTicket.getDescription()))
+                .andExpect(jsonPath("$.content[0].status").value(supportTicket.getStatus().name()));
 
     }
 

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
@@ -202,6 +202,25 @@ public class SupportTicketControllerTest {
                                 .andExpect(jsonPath("$.description").value(supportTicket.getDescription()))
                                 .andExpect(jsonPath("$.status").value(supportTicket.getStatus().name()));
         }
+
+        @Test
+        @DisplayName("should return 404 when calling the update endpoint with valid data and invalid ID")
+        public void testUpdateWithValidDataAndInvalidId() throws Exception {
+                var invalidId = UUID.randomUUID();
+                var request = put("/tickets/{id}", invalidId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body);
+                BDDMockito.given(this.supportTicketService.update(Mockito.eq(invalidId),
+                                Mockito.any(RequestTicketDTO.class)))
+                                .willThrow(new EntityNotFoundException("Ticket not found"));
+                mockMvc.perform(request)
+                                .andExpect(status().isNotFound())
+                                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.path").value("/tickets/" + invalidId))
+                                .andExpect(jsonPath("$.message").value("Ticket not found"))
+                                .andExpect(jsonPath("$.status").value(404))
+                                .andExpect(jsonPath("$.errors").isEmpty());
+        }
         
 
 }

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
@@ -221,6 +221,24 @@ public class SupportTicketControllerTest {
                                 .andExpect(jsonPath("$.status").value(404))
                                 .andExpect(jsonPath("$.errors").isEmpty());
         }
+
+        @Test
+        @DisplayName("should return 400 when calling the update endpoint with invalid data")
+        public void testUpdateWithInvalidData() throws Exception {
+                var invalidRequestBody = "{}";
+                var request = put("/tickets/{id}", supportTicket.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(invalidRequestBody);
+                mockMvc.perform(request)
+                                .andExpect(status().isBadRequest())
+                                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.path").value("/tickets/" + supportTicket.getId()))
+                                .andExpect(jsonPath("$.message").value("Invalid arguments!"))
+                                .andExpect(jsonPath("$.status").value(400))
+                                .andExpect(jsonPath("$.errors").isNotEmpty())
+                                .andExpect(jsonPath("$.errors.title").value("Title must not be empty"))
+                                .andExpect(jsonPath("$.errors.description").value("Description must not be empty"));
+        }
         
 
 }

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
@@ -1,0 +1,41 @@
+package com.rodrigolopes.ms.support_ticket.controllers;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.assertj.MockMvcTester.MockMvcRequestBuilder;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.rodrigolopes.ms.support_ticket.services.SupportTicketService;
+
+@WebMvcTest(SupportTicketController.class)
+public class SupportTicketControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SupportTicketService supportTicketService;
+
+    @Test
+    @DisplayName("Should return 200 when calling the index endpoint")
+    public void testIndex() throws Exception {
+
+       var request = get("/tickets")
+               .contentType(MediaType.APPLICATION_JSON);
+
+
+        mockMvc.perform(request)
+               .andExpect(status().isOk()).andExpect(content().string("hello world"));
+
+    }
+
+}

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
@@ -14,19 +14,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultMatcher;
-import org.springframework.test.web.servlet.assertj.MockMvcTester.MockMvcRequestBuilder;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.catalina.connector.Request;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -110,7 +105,7 @@ public class SupportTicketControllerTest {
 
                 BDDMockito.given(this.supportTicketService.getById(supportTicket.getId()))
                                 .willReturn(responseTicketDTO);
-                                
+
                 mockMvc.perform(request)
                                 .andExpect(status().isOk())
                                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
@@ -39,65 +39,85 @@ import com.rodrigolopes.ms.support_ticket.services.SupportTicketService;
 @WebMvcTest(SupportTicketController.class)
 public class SupportTicketControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+        @Autowired
+        private MockMvc mockMvc;
 
-    @MockitoBean
-    private SupportTicketService supportTicketService;
+        @MockitoBean
+        private SupportTicketService supportTicketService;
 
-    SupportTicket supportTicket;
-    ResponseTicketDTO responseTicketDTO;
-    RequestTicketDTO requestTicketDTO;
-    Page<ResponseTicketDTO> responseTicketDTOPage;
+        SupportTicket supportTicket;
+        ResponseTicketDTO responseTicketDTO;
+        RequestTicketDTO requestTicketDTO;
+        Page<ResponseTicketDTO> responseTicketDTOPage;
 
-    String body;
+        String body;
 
-    @BeforeEach
-    public void setup() throws JsonProcessingException {
-        supportTicket = SupportTicket.builder()
-                .id(UUID.randomUUID())
-                .title("Sample Ticket")
-                .description("This is a sample ticket description.")
-                .status(TicketStatus.OPEN)
-                .build();
-        responseTicketDTO = new ResponseTicketDTO(
-                supportTicket.getId(),
-                supportTicket.getTitle(),
-                supportTicket.getDescription(),
-                supportTicket.getStatus().name(),
-                new Date().toString(),
-                new Date().toString());
+        @BeforeEach
+        public void setup() throws JsonProcessingException {
+                supportTicket = SupportTicket.builder()
+                                .id(UUID.randomUUID())
+                                .title("Sample Ticket")
+                                .description("This is a sample ticket description.")
+                                .status(TicketStatus.OPEN)
+                                .build();
+                responseTicketDTO = new ResponseTicketDTO(
+                                supportTicket.getId(),
+                                supportTicket.getTitle(),
+                                supportTicket.getDescription(),
+                                supportTicket.getStatus().name(),
+                                new Date().toString(),
+                                new Date().toString());
 
-        requestTicketDTO = new RequestTicketDTO(
-                supportTicket.getTitle(),
-                supportTicket.getDescription(),
-                supportTicket.getStatus().name());
+                requestTicketDTO = new RequestTicketDTO(
+                                supportTicket.getTitle(),
+                                supportTicket.getDescription(),
+                                supportTicket.getStatus().name());
 
-        responseTicketDTOPage = new PageImpl<>(List.of(responseTicketDTO), PageRequest.of(0, 100),
-                1);
+                responseTicketDTOPage = new PageImpl<>(List.of(responseTicketDTO), PageRequest.of(0, 100),
+                                1);
 
-        body = new ObjectMapper().writeValueAsString(requestTicketDTO);
+                body = new ObjectMapper().writeValueAsString(requestTicketDTO);
 
-    }
+        }
 
-    @Test
-    @DisplayName("Should return 200 when calling the index endpoint")
-    public void testIndex() throws Exception {
+        @Test
+        @DisplayName("Should return 200 when calling the index endpoint")
+        public void testIndex() throws Exception {
 
-        var request = get("/tickets")
-                .contentType(MediaType.APPLICATION_JSON);
+                var request = get("/tickets")
+                                .contentType(MediaType.APPLICATION_JSON);
 
-        BDDMockito.given(this.supportTicketService.getAll(Mockito.any(Pageable.class)))
-                .willReturn(responseTicketDTOPage);
+                BDDMockito.given(this.supportTicketService.getAll(Mockito.any(Pageable.class)))
+                                .willReturn(responseTicketDTOPage);
 
-        mockMvc.perform(request)
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.content[0].id").value(supportTicket.getId().toString()))
-                .andExpect(jsonPath("$.content[0].title").value(supportTicket.getTitle()))
-                .andExpect(jsonPath("$.content[0].description").value(supportTicket.getDescription()))
-                .andExpect(jsonPath("$.content[0].status").value(supportTicket.getStatus().name()));
+                mockMvc.perform(request)
+                                .andExpect(status().isOk())
+                                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.content[0].id").value(supportTicket.getId().toString()))
+                                .andExpect(jsonPath("$.content[0].title").value(supportTicket.getTitle()))
+                                .andExpect(jsonPath("$.content[0].description").value(supportTicket.getDescription()))
+                                .andExpect(jsonPath("$.content[0].status").value(supportTicket.getStatus().name()));
 
-    }
+        }
+
+        @Test
+        @DisplayName("Should return 200 when calling the show endpoint with valid ID")
+        public void testShowWithValidId() throws Exception {
+
+                var request = get("/tickets/{id}", supportTicket.getId())
+                                                .contentType(MediaType.APPLICATION_JSON);
+
+
+                BDDMockito.given(this.supportTicketService.getById(supportTicket.getId()))
+                                .willReturn(responseTicketDTO);
+                mockMvc.perform(request)
+                                .andExpect(status().isOk())
+                                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.id").value(supportTicket.getId().toString()))
+                                .andExpect(jsonPath("$.title").value(supportTicket.getTitle()))
+                                .andExpect(jsonPath("$.description").value(supportTicket.getDescription()))
+                                .andExpect(jsonPath("$.status").value(supportTicket.getStatus().name())); 
+                              
+        }
 
 }

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/controllers/SupportTicketControllerTest.java
@@ -240,5 +240,22 @@ public class SupportTicketControllerTest {
                                 .andExpect(jsonPath("$.errors.description").value("Description must not be empty"));
         }
         
+        @Test
+        @DisplayName("should return 400 when calling the update endpoint with duplicated title")
+        public void testUpdateWithDuplicatedTitle() throws Exception {
+                var request = put("/tickets/{id}", supportTicket.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body);
+                BDDMockito.given(this.supportTicketService.update(Mockito.eq(supportTicket.getId()),
+                                Mockito.any(RequestTicketDTO.class)))
+                                .willThrow(new IllegalArgumentException("A ticket with this title already exists."));
+                mockMvc.perform(request)
+                                .andExpect(status().isBadRequest())
+                                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.path").value("/tickets/" + supportTicket.getId()))
+                                .andExpect(jsonPath("$.message").value("A ticket with this title already exists."))
+                                .andExpect(jsonPath("$.status").value(400))
+                                .andExpect(jsonPath("$.errors").isEmpty());     
+        }
 
 }

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
@@ -3,6 +3,7 @@ package com.rodrigolopes.ms.support_ticket.service;
 import static org.mockito.Mockito.when;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -16,6 +17,10 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import com.rodrigolopes.ms.support_ticket.dto.RequestTicketDTO;
 import com.rodrigolopes.ms.support_ticket.dto.ResponseTicketDTO;
@@ -63,6 +68,23 @@ public class SupportTicketServiceTest {
                 supportTicket.getTitle(),
                 supportTicket.getDescription(),
                 TicketStatus.OPEN.name());
+    }
+
+    @Test
+    @DisplayName("Should retrieve all support tickets successfully")
+    public void testGetAllSupportTickets() {
+        var pageable = Pageable.unpaged();
+        var page = new PageImpl<>(List.of(supportTicket), PageRequest.of(1, 10), 10);
+        when(ticketSupportRepository.findAll(pageable)).thenReturn(page);
+        when(ticketMapper.toResponseDto(supportTicket)).thenReturn(responseDto);
+
+        Page<ResponseTicketDTO> result = supportTicketService.getAll(pageable);
+
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result.getContent()).hasSize(1);
+        Assertions.assertThat(result.getContent().get(0).id()).isEqualTo(supportTicket.getId());
+        Assertions.assertThat(result.getContent().get(0).title()).isEqualTo("Issue with login");
+        Assertions.assertThat(result.getContent().get(0).description()).isEqualTo("Unable to login with correct credentials");
     }
 
     @Test

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
@@ -143,4 +143,14 @@ public class SupportTicketServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("A ticket with this title already exists in another record.");
     }
+
+    @Test
+    @DisplayName("Should delete a support ticket successfully")
+    public void testDeleteSupportTicket() {
+        var id = UUID.randomUUID();
+        Mockito.when(ticketSupportRepository.findById(id)).thenReturn(Optional.of(supportTicket));
+        supportTicketService.delete(id);
+        Mockito.verify(ticketSupportRepository, Mockito.times(1)).delete(supportTicket);
+        
+    }
 }

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
@@ -66,6 +66,24 @@ public class SupportTicketServiceTest {
     }
 
     @Test
+    @DisplayName("Should retrieve a support ticket by ID successfully")
+    public void testGetSupportTicketById() {
+        var id = UUID.randomUUID();
+        
+        Mockito.when(ticketSupportRepository.findById(id)).thenReturn(Optional.of(supportTicket));
+        Mockito.when(ticketMapper.toResponseDto(supportTicket)).thenReturn(responseDto);
+        
+        var result = supportTicketService.getById(id);
+        
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result.id()).isEqualTo(supportTicket.getId());
+        Assertions.assertThat(result.title()).isEqualTo("Issue with login");
+        Assertions.assertThat(result.description()).isEqualTo("Unable to login with correct credentials");
+        
+        Mockito.verify(ticketSupportRepository, Mockito.times(1)).findById(id);
+    }
+
+    @Test
     @DisplayName("Should create a support ticket successfully")
     public void testCreateSupportTicket() {
 
@@ -75,7 +93,6 @@ public class SupportTicketServiceTest {
         Mockito.when(ticketSupportRepository.save(Mockito.any(SupportTicket.class))).thenReturn(supportTicket);
 
         ResponseTicketDTO result = supportTicketService.create(requestDto);
-
 
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result.id()).isEqualTo(supportTicket.getId());
@@ -90,7 +107,6 @@ public class SupportTicketServiceTest {
     @DisplayName("Should throw exception when creating a ticket with duplicate title")
     public void testCreateSupportTicket_DuplicateTitle() {
         Mockito.when(ticketSupportRepository.existsByTitle(Mockito.anyString())).thenReturn(true);
-
 
         Assertions.assertThatThrownBy(() -> supportTicketService.create(requestDto))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -114,7 +130,6 @@ public class SupportTicketServiceTest {
         var result = supportTicketService.update(id, requestDto);
 
         Assertions.assertThat(result).isNotNull();
-
 
         Mockito.verify(ticketSupportRepository, Mockito.times(1)).findById(id);
         Mockito.verify(ticketSupportRepository, Mockito.times(1)).save(supportTicket);
@@ -140,7 +155,6 @@ public class SupportTicketServiceTest {
         Mockito.when(ticketSupportRepository.findById(id)).thenReturn(Optional.of(supportTicket));
         Mockito.when(ticketSupportRepository.existsByTitleAndIdNot(requestDto.title(), id)).thenReturn(true);
 
-
         Assertions.assertThatThrownBy(() -> supportTicketService.update(id, requestDto))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("A ticket with this title already exists in another record.");
@@ -154,12 +168,13 @@ public class SupportTicketServiceTest {
     public void testDeleteSupportTicket() {
         var id = UUID.randomUUID();
         Mockito.when(ticketSupportRepository.existsById(id)).thenReturn(true);
-        
+
         supportTicketService.delete(id);
-        
+
         Mockito.verify(ticketSupportRepository, Mockito.times(1)).deleteById(id);
 
     }
+
     @Test
     @DisplayName("Should throw exception when deleting a non-existent ticket")
     public void testDeleteSupportTicket_NotFound() {

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
@@ -1,5 +1,7 @@
 package com.rodrigolopes.ms.support_ticket.service;
 
+import static org.mockito.Mockito.when;
+
 import java.util.Date;
 import java.util.UUID;
 
@@ -37,6 +39,7 @@ public class SupportTicketServiceTest {
     ResponseTicketDTO responseDto;
     SupportTicket supportTicket;
     RequestTicketDTO requestDto;
+
     @BeforeEach
     public void setup() {
         supportTicket = SupportTicket.builder()
@@ -44,23 +47,32 @@ public class SupportTicketServiceTest {
                 .title("Issue with login")
                 .description("Unable to login with correct credentials")
                 .build();
-        responseDto = new ResponseTicketDTO(supportTicket.getId(),
+
+        responseDto = new ResponseTicketDTO(
+                supportTicket.getId(),
                 supportTicket.getTitle(),
-                supportTicket.getDescription(), TicketStatus.OPEN.name(), new Date().toString(), new Date().toString());
-        requestDto = ticketMapper.toRequestDto(supportTicket);
+                supportTicket.getDescription(),
+                TicketStatus.OPEN.name(),
+                new Date().toString(),
+                new Date().toString());
+
+        requestDto = new RequestTicketDTO(
+                supportTicket.getTitle(),
+                supportTicket.getDescription(),
+                TicketStatus.OPEN.name());
     }
 
     @Test
     @DisplayName("Should create a support ticket successfully")
     public void testCreateSupportTicket() {
-        // Arrange
 
         Mockito.when(ticketMapper.toEntity(requestDto)).thenReturn(supportTicket);
         Mockito.when(ticketMapper.toResponseDto(supportTicket)).thenReturn(responseDto);
+        Mockito.when(ticketSupportRepository.existsByTitle(Mockito.anyString())).thenReturn(false);
         Mockito.when(ticketSupportRepository.save(Mockito.any(SupportTicket.class))).thenReturn(supportTicket);
 
         // Act
-        ResponseTicketDTO result = supportTicketService.createTicket(requestDto);
+        ResponseTicketDTO result = supportTicketService.create(requestDto);
 
         // Assert
         Assertions.assertThat(result).isNotNull();

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
@@ -69,18 +69,30 @@ public class SupportTicketServiceTest {
     @DisplayName("Should retrieve a support ticket by ID successfully")
     public void testGetSupportTicketById() {
         var id = UUID.randomUUID();
-        
+
         Mockito.when(ticketSupportRepository.findById(id)).thenReturn(Optional.of(supportTicket));
         Mockito.when(ticketMapper.toResponseDto(supportTicket)).thenReturn(responseDto);
-        
+
         var result = supportTicketService.getById(id);
-        
+
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result.id()).isEqualTo(supportTicket.getId());
         Assertions.assertThat(result.title()).isEqualTo("Issue with login");
         Assertions.assertThat(result.description()).isEqualTo("Unable to login with correct credentials");
-        
+
         Mockito.verify(ticketSupportRepository, Mockito.times(1)).findById(id);
+    }
+
+    @Test
+    @DisplayName("Should throw exception when ticket not found by ID")
+    public void testGetSupportTicketById_NotFound() {
+        var id = UUID.randomUUID();
+        Mockito.when(ticketSupportRepository.findById(id)).thenReturn(Optional.empty());
+        Assertions.assertThatThrownBy(() -> supportTicketService.getById(id))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("Ticket not found with id: " + id);
+        Mockito.verify(ticketSupportRepository, Mockito.times(1)).findById(id);
+
     }
 
     @Test

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
@@ -1,5 +1,6 @@
 package com.rodrigolopes.ms.support_ticket.service;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -7,14 +8,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 
+import com.rodrigolopes.ms.support_ticket.dto.RequestTicketDTO;
 import com.rodrigolopes.ms.support_ticket.entities.SupportTicket;
+import com.rodrigolopes.ms.support_ticket.mapper.TicketMapper;
 import com.rodrigolopes.ms.support_ticket.repositories.TicketSupportRepository;
 import com.rodrigolopes.ms.support_ticket.services.SupportTicketService;
 
 @ExtendWith(MockitoExtension.class)
 public class SupportTicketServiceTest {
-    
 
     @InjectMocks
     private SupportTicketService supportTicketService;
@@ -22,11 +25,25 @@ public class SupportTicketServiceTest {
     @Mock
     private TicketSupportRepository ticketSupportRepository;
 
-
+    @Autowired 
+    private TicketMapper ticketMapper;
     @Test
     @DisplayName("Should create a support ticket successfully")
     public void testCreateSupportTicket() {
         
+        SupportTicket supportTicket = SupportTicket.builder()
+                .title("Issue with login")
+                .description("Unable to login with correct credentials")
+                .build();
+        RequestTicketDTO requestDto = ticketMapper.toRequestDto(supportTicket);
+        Mockito.when(ticketSupportRepository.save(supportTicket)).thenReturn(supportTicket);
 
+
+        var result = supportTicketService.createTicket(requestDto);
+
+
+        Assertions.assertThat(result).isNotNull();
+
+        
     }
 }

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
@@ -25,7 +25,7 @@ public class SupportTicketServiceTest {
     @Mock
     private TicketSupportRepository ticketSupportRepository;
 
-    @Autowired 
+    @Mock
     private TicketMapper ticketMapper;
     @Test
     @DisplayName("Should create a support ticket successfully")

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
@@ -84,4 +84,18 @@ public class SupportTicketServiceTest {
                 .save(Mockito.any(SupportTicket.class));
     }
 
+
+    @Test
+    @DisplayName("Should throw exception when creating a ticket with duplicate title")
+    public void testCreateSupportTicket_DuplicateTitle() {
+        Mockito.when(ticketSupportRepository.existsByTitle(Mockito.anyString())).thenReturn(true);
+
+        // Act & Assert
+        Assertions.assertThatThrownBy(() -> supportTicketService.create(requestDto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("A ticket with this title already exists.");
+
+        Mockito.verify(ticketSupportRepository, Mockito.never())
+                .save(Mockito.any(SupportTicket.class));
+    }
 }

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
@@ -1,0 +1,32 @@
+package com.rodrigolopes.ms.support_ticket.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.rodrigolopes.ms.support_ticket.entities.SupportTicket;
+import com.rodrigolopes.ms.support_ticket.repositories.TicketSupportRepository;
+import com.rodrigolopes.ms.support_ticket.services.SupportTicketService;
+
+@ExtendWith(MockitoExtension.class)
+public class SupportTicketServiceTest {
+    
+
+    @InjectMocks
+    private SupportTicketService supportTicketService;
+
+    @Mock
+    private TicketSupportRepository ticketSupportRepository;
+
+
+    @Test
+    @DisplayName("Should create a support ticket successfully")
+    public void testCreateSupportTicket() {
+        
+
+    }
+}

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
@@ -74,10 +74,9 @@ public class SupportTicketServiceTest {
         Mockito.when(ticketSupportRepository.existsByTitle(Mockito.anyString())).thenReturn(false);
         Mockito.when(ticketSupportRepository.save(Mockito.any(SupportTicket.class))).thenReturn(supportTicket);
 
-        // Act
         ResponseTicketDTO result = supportTicketService.create(requestDto);
 
-        // Assert
+
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result.id()).isEqualTo(supportTicket.getId());
         Assertions.assertThat(result.title()).isEqualTo("Issue with login");
@@ -92,7 +91,7 @@ public class SupportTicketServiceTest {
     public void testCreateSupportTicket_DuplicateTitle() {
         Mockito.when(ticketSupportRepository.existsByTitle(Mockito.anyString())).thenReturn(true);
 
-        // Act & Assert
+
         Assertions.assertThatThrownBy(() -> supportTicketService.create(requestDto))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("A ticket with this title already exists.");
@@ -129,6 +128,9 @@ public class SupportTicketServiceTest {
         Assertions.assertThatThrownBy(() -> supportTicketService.update(id, requestDto))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessage("Ticket not found with id: " + id);
+
+        Mockito.verify(ticketSupportRepository, Mockito.times(1)).findById(id);
+        Mockito.verify(ticketSupportRepository, Mockito.never()).save(supportTicket);
     }
 
     @Test
@@ -142,6 +144,9 @@ public class SupportTicketServiceTest {
         Assertions.assertThatThrownBy(() -> supportTicketService.update(id, requestDto))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("A ticket with this title already exists in another record.");
+
+        Mockito.verify(ticketSupportRepository, Mockito.times(1)).findById(id);
+        Mockito.verify(ticketSupportRepository, Mockito.never()).save(supportTicket);
     }
 
     @Test
@@ -154,5 +159,16 @@ public class SupportTicketServiceTest {
         
         Mockito.verify(ticketSupportRepository, Mockito.times(1)).deleteById(id);
 
+    }
+    @Test
+    @DisplayName("Should throw exception when deleting a non-existent ticket")
+    public void testDeleteSupportTicket_NotFound() {
+        var id = UUID.randomUUID();
+        Mockito.when(ticketSupportRepository.existsById(id)).thenReturn(false);
+        Assertions.assertThatThrownBy(() -> supportTicketService.delete(id))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("Ticket not found with id: " + id);
+
+        Mockito.verify(ticketSupportRepository, Mockito.never()).deleteById(id);
     }
 }

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
@@ -1,6 +1,10 @@
 package com.rodrigolopes.ms.support_ticket.service;
 
+import java.util.Date;
+import java.util.UUID;
+
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,7 +15,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.rodrigolopes.ms.support_ticket.dto.RequestTicketDTO;
+import com.rodrigolopes.ms.support_ticket.dto.ResponseTicketDTO;
 import com.rodrigolopes.ms.support_ticket.entities.SupportTicket;
+import com.rodrigolopes.ms.support_ticket.enums.TicketStatus;
 import com.rodrigolopes.ms.support_ticket.mapper.TicketMapper;
 import com.rodrigolopes.ms.support_ticket.repositories.TicketSupportRepository;
 import com.rodrigolopes.ms.support_ticket.services.SupportTicketService;
@@ -27,23 +33,43 @@ public class SupportTicketServiceTest {
 
     @Mock
     private TicketMapper ticketMapper;
-    @Test
-    @DisplayName("Should create a support ticket successfully")
-    public void testCreateSupportTicket() {
-        
-        SupportTicket supportTicket = SupportTicket.builder()
+
+    ResponseTicketDTO responseDto;
+    SupportTicket supportTicket;
+    RequestTicketDTO requestDto;
+    @BeforeEach
+    public void setup() {
+        supportTicket = SupportTicket.builder()
+                .id(UUID.randomUUID())
                 .title("Issue with login")
                 .description("Unable to login with correct credentials")
                 .build();
-        RequestTicketDTO requestDto = ticketMapper.toRequestDto(supportTicket);
-        Mockito.when(ticketSupportRepository.save(supportTicket)).thenReturn(supportTicket);
-
-
-        var result = supportTicketService.createTicket(requestDto);
-
-
-        Assertions.assertThat(result).isNotNull();
-
-        
+        responseDto = new ResponseTicketDTO(supportTicket.getId(),
+                supportTicket.getTitle(),
+                supportTicket.getDescription(), TicketStatus.OPEN.name(), new Date().toString(), new Date().toString());
+        requestDto = ticketMapper.toRequestDto(supportTicket);
     }
+
+    @Test
+    @DisplayName("Should create a support ticket successfully")
+    public void testCreateSupportTicket() {
+        // Arrange
+
+        Mockito.when(ticketMapper.toEntity(requestDto)).thenReturn(supportTicket);
+        Mockito.when(ticketMapper.toResponseDto(supportTicket)).thenReturn(responseDto);
+        Mockito.when(ticketSupportRepository.save(Mockito.any(SupportTicket.class))).thenReturn(supportTicket);
+
+        // Act
+        ResponseTicketDTO result = supportTicketService.createTicket(requestDto);
+
+        // Assert
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result.id()).isEqualTo(supportTicket.getId());
+        Assertions.assertThat(result.title()).isEqualTo("Issue with login");
+        Assertions.assertThat(result.description()).isEqualTo("Unable to login with correct credentials");
+
+        Mockito.verify(ticketSupportRepository, Mockito.times(1))
+                .save(Mockito.any(SupportTicket.class));
+    }
+
 }

--- a/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
+++ b/src/test/java/com/rodrigolopes/ms/support_ticket/service/SupportTicketServiceTest.java
@@ -148,9 +148,11 @@ public class SupportTicketServiceTest {
     @DisplayName("Should delete a support ticket successfully")
     public void testDeleteSupportTicket() {
         var id = UUID.randomUUID();
-        Mockito.when(ticketSupportRepository.findById(id)).thenReturn(Optional.of(supportTicket));
-        supportTicketService.delete(id);
-        Mockito.verify(ticketSupportRepository, Mockito.times(1)).delete(supportTicket);
+        Mockito.when(ticketSupportRepository.existsById(id)).thenReturn(true);
         
+        supportTicketService.delete(id);
+        
+        Mockito.verify(ticketSupportRepository, Mockito.times(1)).deleteById(id);
+
     }
 }


### PR DESCRIPTION
### Create Ticket Support Resources

- Implemented full CRUD operations for Support Ticket (Create, Read, Update, Delete).
- Integrated MapStruct to map DTOs to entities.
- Added error handlers for consistent API error responses.
- Implemented data validation using Bean Validation.
- Wrote unit tests with JUnit, Mockito, and AssertJ, achieving 100% test coverage.